### PR TITLE
Update git cmds to use switch instead of checkout

### DIFF
--- a/lessons/git/basics_branching.sh
+++ b/lessons/git/basics_branching.sh
@@ -51,7 +51,7 @@ GIT_EDITOR="echo \"$second_msg\" >" git commit
 git branch
 git branch doplneni-autora
 git branch
-git checkout doplneni-autora
+git switch doplneni-autora
 git branch
 
 cat > basnicka.txt << END
@@ -73,9 +73,9 @@ GIT_EDITOR='echo "Doplnění autora" >' git commit
 
 take_screenshot $OUTFILE.branch1.png gitk --all
 
-git checkout master
+git switch master
 git branch doplneni-jmena
-git checkout doplneni-jmena
+git switch doplneni-jmena
 git branch
 
 cat > basnicka.txt << END
@@ -97,7 +97,7 @@ GIT_EDITOR='echo "Doplnění jména" >' git commit
 
 take_screenshot $OUTFILE.branches.png gitk --all
 
-git checkout master
+git switch master
 git merge doplneni-jmena
 git merge doplneni-autora
 git status

--- a/lessons/git/branching/index.md
+++ b/lessons/git/branching/index.md
@@ -55,7 +55,7 @@ Hvězdička ve výstupu z `git branch` ukazuje,
 Na přepnutí budeš potřebovat další příkaz:
 
 ```ansi
-␛[36m$␛[0m git checkout doplneni-autora
+␛[36m$␛[0m git switch doplneni-autora
 Switched to branch 'doplneni-autora'
 ␛[36m$␛[0m git branch
 * ␛[32mdoplneni-autora␛[m
@@ -82,10 +82,10 @@ větev `doplneni-jmena`.
 Pak se na tuhle novou větev přepni.
 
 ```ansi
-␛[36m$␛[0m git checkout master
+␛[36m$␛[0m git switch master
 Switched to branch 'master'
 ␛[36m$␛[0m git branch doplneni-jmena
-␛[36m$␛[0m git checkout doplneni-jmena
+␛[36m$␛[0m git switch doplneni-jmena
 Switched to branch 'doplneni-jmena'
 ␛[36m$␛[0m git branch
   doplneni-autora␛[m
@@ -135,7 +135,7 @@ sloučí jinou větev s tou aktuální.
 Příkazu musíš dát jméno větve, kterou chceš sloučit.
 
 ```ansi
-␛[36m$␛[0m git checkout master
+␛[36m$␛[0m git switch master
 Switched to branch 'master'
 ␛[36m$␛[0m git merge doplneni-jmena
 Updating 1fcd654..5c9bf93

--- a/lessons/git/collaboration/index.md
+++ b/lessons/git/collaboration/index.md
@@ -184,7 +184,7 @@ Například pomocí:
 
 ```console
 $ git branch pridani-jmena
-$ git checkout pridani-jmena
+$ git switch pridani-jmena
 ```
 
 


### PR DESCRIPTION
Git checkout is doing switch + restore. We only need to switch to the branch.